### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/delta-n-devops/e62907fa-7178-4f72-a0af-600320fc914b/b55617ff-4da9-4d5f-a014-12eed204605d/_apis/work/boardbadge/b8903358-bdb0-4b40-93fe-580237f8df1b)](https://dev.azure.com/delta-n-devops/e62907fa-7178-4f72-a0af-600320fc914b/_boards/board/t/b55617ff-4da9-4d5f-a014-12eed204605d/Microsoft.RequirementCategory)
 # testissues


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#562. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.